### PR TITLE
Power refute in the same manner with power assert.

### DIFF
--- a/lib/minitest/power_assert.rb
+++ b/lib/minitest/power_assert.rb
@@ -16,6 +16,17 @@ module Minitest
           super test, msg
         end
       end
+
+      def refute test = nil, msg = nil, &blk
+        if block_given?
+          ::PowerAssert.start(blk, assertion_method: __method__) do |pa|
+            # XXX workaround to break inline format with minitest-reporters.
+            super pa.yield, "\n#{pa.message_proc.call}"
+          end
+        else
+          super test, msg
+        end
+      end
     end
   end
 

--- a/test/test_power_assert.rb
+++ b/test/test_power_assert.rb
@@ -25,4 +25,27 @@ class TestPowerAssert < Minitest::Test
   rescue Minitest::Assertion => e
     assert_match(/Failed assertion, no message given./, e.message)
   end
+
+  def test_power_refute
+    refute { false }
+  end
+
+  def test_power_refute_failed
+    refute { "0".each_char.class == "3".to_i.times.map {|i| i + 1 }.class }
+  rescue Minitest::Assertion => e
+    assert_match(/Array/, e.message)
+    assert_match(/\[1, 2, 3\]/, e.message)
+    assert_match(/#<Enumerator: 3:times>/, e.message)
+    assert_match(/#<Enumerator: \"0\":each_char>"/, e.message)
+  end
+
+  def test_refute
+    refute false
+  end
+
+  def test_refute_failed
+    refute "0".each_char.class == "3".to_i.times.map {|i| i + 1 }.class
+  rescue Minitest::Assertion => e
+    assert_match(/Failed assertion, no message given./, e.message)
+  end
 end


### PR DESCRIPTION
Currently, `minitest-power_assert` gem provides `assert {}` but its counter part `refute {}`.
This commit approaches the problem by simply repeating the code of `assert` for `refute`.

I know it should be dried up with metaprogramming. Since I couldn't do it, I shamelessly leave it for now.