### PR TITLE
Avoid Proc without a block to fix Ruby 2.7 warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+vendor
 *.bundle
 *.so
 *.o

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
+dist: xenial
 language: ruby
-
-before_install: gem update bundler --no-document
-
 rvm:
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
-  - ruby-head
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
+cache:
+  bundler: true
+script:
+  - bundle exec rake

--- a/lib/minitest/power_assert.rb
+++ b/lib/minitest/power_assert.rb
@@ -6,9 +6,9 @@ require 'power_assert'
 module Minitest
   module PowerAssert
     module Assertions
-      def assert(test = nil, msg = nil)
+      def assert(test = nil, msg = nil, &block)
         if block_given?
-          ::PowerAssert.start(Proc.new, assertion_method: __method__) do |pa|
+          ::PowerAssert.start(block, assertion_method: __method__) do |pa|
             super pa.yield, pa.extend(ContextExtension)
           end
         else
@@ -16,9 +16,9 @@ module Minitest
         end
       end
 
-      def refute(test = nil, msg = nil)
+      def refute(test = nil, msg = nil, &block)
         if block_given?
-          ::PowerAssert.start(Proc.new, assertion_method: __method__) do |pa|
+          ::PowerAssert.start(block, assertion_method: __method__) do |pa|
             super pa.yield, pa.extend(ContextExtension)
           end
         else

--- a/minitest-power_assert.gemspec
+++ b/minitest-power_assert.gemspec
@@ -21,6 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "minitest"
   spec.add_dependency "power_assert", ">= 1.1"
 
-  spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
This PR fixes warnings with Ruby 2.7:
```
warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
```